### PR TITLE
Normalize sql between 'street 4' and 'street 4 casing' layers

### DIFF
--- a/mapquest_inc/layer-transportation-us.xml.inc
+++ b/mapquest_inc/layer-transportation-us.xml.inc
@@ -926,12 +926,12 @@
 	<StyleName>street 4</StyleName>
 	<Datasource>
 		<Parameter name="table">
-	      (select way,highway,
+	      (select way,highway,railway,
 	       case when tunnel in ('yes','true','1') then 'yes'::text else tunnel end as tunnel
 	       from &prefix;_line
 	       where highway in ('residential', 'living_street', 'unclassified', 'road', 'residential_link', 'unclassified_link')
 	       order by z_order
-	      ) as roads
+	      ) as roads			
       </Parameter>
       &datasource-settings;
 	</Datasource>


### PR DESCRIPTION
The street 4 layer is using a slightly different sql from street 4 casing, which I imagine is a copy-n-paste error from some time past when railway conditions were added to street 4 casing.  This commit normalizes them.  I'm using a tool that heuristically checks for similar sql between layers and this is tripping it up.
